### PR TITLE
Feature/capabilities replacements expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ sitmun:
     config:
       url: http://some.url
       secret: some-secret
-  wms:
+  ogc:
     capabilities:
       # OGC service path suffixes recognized when rewriting URLs in GetCapabilities responses.
       service-paths:

--- a/README.md
+++ b/README.md
@@ -368,13 +368,14 @@ Response:
 
 ### Environment Variables
 
-| Variable | Description | Required | Default |
-|----------|-------------|----------|---------|
-| `SITMUN_BACKEND_CONFIG_URL` | URL to backend configuration service | Yes | - |
-| `SITMUN_BACKEND_CONFIG_SECRET` | Secret key for configuration access | Yes | - |
-| `SERVER_PORT` | Application port | No | 8080 |
-| `SPRING_PROFILES_ACTIVE` | Spring profile to use | No | prod |
-
+| Variable | Description | Required | Default           |
+|----------|-------------|----------|-------------------|
+| `SITMUN_BACKEND_CONFIG_URL` | URL to backend configuration service | Yes | -                 |
+| `SITMUN_BACKEND_CONFIG_SECRET` | Secret key for configuration access | Yes | -                 |
+| `SERVER_PORT` | Application port | No | 8080              |
+| `SPRING_PROFILES_ACTIVE` | Spring profile to use | No | prod              |
+| `SITMUN_OGC_CAPABILITIES_SERVICE_PATHS` | Comma-separated OGC service path suffixes recognized when rewriting URLs in `GetCapabilities` responses | No | `wms,wfs,wcs,ows` |
+| `SITMUN_OGC_CAPABILITIES_EXTRA_SOURCES` | Comma-separated list of additional source URL prefixes to replace with the proxy URL in `GetCapabilities` responses. Use this when the backend exposes an internal address (e.g. `localhost`, a private IP) that differs from the URL configured in SITMUN | No | Empty list |
 ### Profiles
 
 #### Development Profile (`dev`)
@@ -408,6 +409,18 @@ sitmun:
     config:
       url: http://some.url
       secret: some-secret
+  wms:
+    capabilities:
+      # OGC service path suffixes recognized when rewriting URLs in GetCapabilities responses.
+      service-paths:
+        - wms
+        - wfs
+        - wcs
+        - ows
+      # Optional extra source URL prefixes to replace with the proxy URL (empty list by default).
+      extra-sources:
+       - http://localhost:3000
+       - http://internal-geoserver:8080/geoserver
 
 # Actuator Configuration
 management:
@@ -1119,6 +1132,26 @@ The Proxy Middleware supports different service types that can be configured in 
     "password": "protected_pass"
   }
 }
+```
+
+##### GetCapabilities URL Rewriting
+
+When a `GetCapabilities` request is proxied, the response body is post-processed to replace internal service URLs with the public proxy URL. This prevents the proxy being ignored on future requests.
+
+Two replacement steps are applied:
+
+1. **Default source**: the base URL configured in SITMUN (stripping query string and trailing OGC suffix). All its occurrences in the response body are replaced.
+2. **Extra sources**: any additional URL prefixes declared in `extra-sources` are also replaced. This covers cases where the capabilities response URLs differ from the URL stored in SITMUN. Only address before OGC suffix is taken into account.
+
+Only URLs in quoted attributes are replaced, avoiding false positives.
+
+**Example environment variables:**
+```bash
+# Override recognized OGC suffixes (optional, defaults to wms,wfs,wcs,ows)
+SITMUN_OGC_CAPABILITIES_SERVICE_PATHS=wms,wfs,wcs,ows
+
+# Replace custom addresses found in the capabilities body (optional, defaults to empty list)
+SITMUN_OGC_CAPABILITIES_EXTRA_SOURCES=http://localhost:3000,http://internal-geoserver:8080/geoserver
 ```
 
 #### JDBC Services

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - SITMUN_BACKEND_CONFIG_URL=http://sitmun-backend:8080
       - SITMUN_BACKEND_CONFIG_SECRET=your-secret-key-here
       
+      # Capabilities replacements configuration
+      - SITMUN_OGC_CAPABILITIES_SERVICE_PATHS=wms,wfs,wcs,ows
+      # - SITMUN_OGC_CAPABILITIES_EXTRA_SOURCES=http://localhost:3000,http://internal:8080/geoserver
+      
       # Actuator Configuration
       - MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,metrics
       - MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS=never

--- a/src/main/java/org/sitmun/proxy/middleware/config/ProxyMiddlewareConfiguration.java
+++ b/src/main/java/org/sitmun/proxy/middleware/config/ProxyMiddlewareConfiguration.java
@@ -1,6 +1,8 @@
 package org.sitmun.proxy.middleware.config;
 
 import java.time.Duration;
+import org.sitmun.proxy.middleware.protocols.wms.WmsCapabilitiesProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +13,7 @@ import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @Configuration
+@EnableConfigurationProperties(WmsCapabilitiesProperties.class)
 public class ProxyMiddlewareConfiguration {
 
   @Bean

--- a/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesProperties.java
+++ b/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesProperties.java
@@ -1,0 +1,17 @@
+package org.sitmun.proxy.middleware.protocols.wms;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sitmun.ogc.capabilities")
+@Getter
+@Setter
+public class WmsCapabilitiesProperties {
+
+  private List<String> servicePaths = new ArrayList<>(List.of("wms", "wfs", "wcs", "ows"));
+
+  private List<String> extraSources = new ArrayList<>();
+}

--- a/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecorator.java
+++ b/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecorator.java
@@ -1,7 +1,9 @@
 package org.sitmun.proxy.middleware.protocols.wms;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sitmun.proxy.middleware.decorator.Context;
 import org.sitmun.proxy.middleware.decorator.ResponseDecorator;
@@ -10,7 +12,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class WmsCapabilitiesResponseDecorator implements ResponseDecorator {
+
+  private final WmsCapabilitiesProperties properties;
 
   @Override
   public boolean accept(Object target, Context context) {
@@ -33,27 +38,42 @@ public class WmsCapabilitiesResponseDecorator implements ResponseDecorator {
       String s = new String(requestExecutionResponseImpl1.getBody(), StandardCharsets.UTF_8);
       String fullUri = wmsPayloadDto.getUri();
       String baseUri = fullUri.split("\\?")[0];
-      
+
       log.debug("WMS PAYLOAD FULL URI: {}", fullUri);
       log.debug("WMS PAYLOAD BASE URI: {}", baseUri);
       log.debug("REQ EXEC RES URL: {}", requestExecutionResponseImpl1.getBaseUrl());
-      
+
       String baseUrl = requestExecutionResponseImpl1.getBaseUrl();
+      List<String> servicePaths = properties.getServicePaths();
+      String servicePathSuffixes = String.join("|", servicePaths);
 
-      String servicePath = baseUri.replaceAll("/(?:wms|wfs|wcs|ows)/?$", "");
-      
-      log.info("GEOSERVER PATH: {}", servicePath);
+      String servicePath = baseUri.replaceAll("/(?:" + servicePathSuffixes + ")/?$", "");
+      log.info("SERVICE PATH: {}", servicePath);
+      s = replace(s, servicePath, servicePathSuffixes, baseUrl);
 
-      Pattern pattern = Pattern.compile(
-          Pattern.quote(servicePath) + "(?:/(?:wms|wfs|wcs|ows))?(?=[?'\"]|\\s|$)",
-          Pattern.CASE_INSENSITIVE);
-      String output = pattern.matcher(s).replaceAll(baseUrl);
-      
-      log.info(
-          "Replacement of {} by {} in GetCapabilities response",
-          servicePath,
-          baseUrl);
-      requestExecutionResponseImpl1.setBody(output.getBytes(StandardCharsets.UTF_8));
+      for (String extraSource : properties.getExtraSources()) {
+        String normalizedSource = extraSource.replaceAll("/(?:" + servicePathSuffixes + ")/?$", "");
+        log.info("EXTRA SOURCE: {}", normalizedSource);
+        s = replace(s, normalizedSource, servicePathSuffixes, baseUrl);
+      }
+
+      requestExecutionResponseImpl1.setBody(s.getBytes(StandardCharsets.UTF_8));
     }
+  }
+
+  /**
+   * Replaces all quoted occurrences of {@code source}
+   */
+  private String replace(String content, String source, String servicePathSuffixes, String target) {
+    Pattern pattern = Pattern.compile(
+        "(?<=[\"'])" + Pattern.quote(source) + "(?:/(?:" + servicePathSuffixes + "))?(?=[?\"'\\s]|$)",
+        Pattern.CASE_INSENSITIVE);
+    String result = pattern.matcher(content).replaceAll(target);
+    if (!result.equals(content)) {
+      log.info("Replacement of {} by {} in GetCapabilities response", source, target);
+    } else {
+      log.warn("No replacements of {} by {} were done in GetCapabilities response", source, target);
+    }
+    return result;
   }
 }

--- a/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecorator.java
+++ b/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecorator.java
@@ -1,6 +1,7 @@
 package org.sitmun.proxy.middleware.protocols.wms;
 
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.sitmun.proxy.middleware.decorator.Context;
 import org.sitmun.proxy.middleware.decorator.ResponseDecorator;
@@ -30,12 +31,28 @@ public class WmsCapabilitiesResponseDecorator implements ResponseDecorator {
       RequestExecutorResponseImpl<byte[]> requestExecutionResponseImpl1 =
           (RequestExecutorResponseImpl<byte[]>) response;
       String s = new String(requestExecutionResponseImpl1.getBody(), StandardCharsets.UTF_8);
-      String output =
-          s.replaceAll(wmsPayloadDto.getUri(), requestExecutionResponseImpl1.getBaseUrl());
+      String fullUri = wmsPayloadDto.getUri();
+      String baseUri = fullUri.split("\\?")[0];
+      
+      log.debug("WMS PAYLOAD FULL URI: {}", fullUri);
+      log.debug("WMS PAYLOAD BASE URI: {}", baseUri);
+      log.debug("REQ EXEC RES URL: {}", requestExecutionResponseImpl1.getBaseUrl());
+      
+      String baseUrl = requestExecutionResponseImpl1.getBaseUrl();
+
+      String servicePath = baseUri.replaceAll("/(?:wms|wfs|wcs|ows)/?$", "");
+      
+      log.info("GEOSERVER PATH: {}", servicePath);
+
+      Pattern pattern = Pattern.compile(
+          Pattern.quote(servicePath) + "(?:/(?:wms|wfs|wcs|ows))?(?=[?'\"]|\\s|$)",
+          Pattern.CASE_INSENSITIVE);
+      String output = pattern.matcher(s).replaceAll(baseUrl);
+      
       log.info(
           "Replacement of {} by {} in GetCapabilities response",
-          wmsPayloadDto.getUri(),
-          requestExecutionResponseImpl1.getBaseUrl());
+          servicePath,
+          baseUrl);
       requestExecutionResponseImpl1.setBody(output.getBytes(StandardCharsets.UTF_8));
     }
   }

--- a/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecorator.java
+++ b/src/main/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecorator.java
@@ -61,13 +61,16 @@ public class WmsCapabilitiesResponseDecorator implements ResponseDecorator {
     }
   }
 
-  /**
-   * Replaces all quoted occurrences of {@code source}
-   */
+  /** Replaces all quoted occurrences of {@code source} */
   private String replace(String content, String source, String servicePathSuffixes, String target) {
-    Pattern pattern = Pattern.compile(
-        "(?<=[\"'])" + Pattern.quote(source) + "(?:/(?:" + servicePathSuffixes + "))?(?=[?\"'\\s]|$)",
-        Pattern.CASE_INSENSITIVE);
+    Pattern pattern =
+        Pattern.compile(
+            "(?<=[\"'])"
+                + Pattern.quote(source)
+                + "(?:/(?:"
+                + servicePathSuffixes
+                + "))?(?=[?\"'\\s]|$)",
+            Pattern.CASE_INSENSITIVE);
     String result = pattern.matcher(content).replaceAll(target);
     if (!result.equals(content)) {
       log.info("Replacement of {} by {} in GetCapabilities response", source, target);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,14 @@ sitmun:
     config:
       url: http://some.url
       secret: some-secret
+  ogc:
+    capabilities:
+      service-paths:
+        - wms
+        - wfs
+        - wcs
+        - ows
+      extra-sources: []
 
 # Actuator Configuration
 management:

--- a/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
+++ b/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
@@ -198,57 +198,56 @@ class WmsCapabilitiesResponseDecoratorTest {
   @DisplayName("replaces all quoted URLs in a full WMS GetCapabilities response")
   void fullWmsCapabilitiesExample() {
     String inputXml =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<WMS_Capabilities version=\"1.3.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
-            + "\n"
-            + "  <Service>\n"
-            + "    <Name>WMS</Name>\n"
-            + "    <Title>My GeoServer</Title>\n"
-            + "    <OnlineResource xlink:href=\""
-            + GEOSERVER
-            + "?SERVICE=WMS\"/>\n"
-            + "  </Service>\n"
-            + "\n"
-            + "  <Capability>\n"
-            + "    <Request>\n"
-            + "\n"
-            + "      <GetCapabilities>\n"
-            + "        <DCPType><HTTP>\n"
-            + "          <Get><OnlineResource  xlink:href=\""
-            + GEOSERVER
-            + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Get>\n"
-            + "          <Post><OnlineResource xlink:href=\""
-            + GEOSERVER
-            + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Post>\n"
-            + "        </HTTP></DCPType>\n"
-            + "      </GetCapabilities>\n"
-            + "\n"
-            + "      <GetMap>\n"
-            + "        <DCPType><HTTP>\n"
-            + "          <Get><OnlineResource xlink:href=\""
-            + GEOSERVER
-            + "/wms?SERVICE=WMS&amp;REQUEST=GetMap\"/></Get>\n"
-            + "        </HTTP></DCPType>\n"
-            + "      </GetMap>\n"
-            + "\n"
-            + "      <GetFeatureInfo>\n"
-            + "        <DCPType><HTTP>\n"
-            + "          <Get><OnlineResource xlink:href=\""
-            + GEOSERVER
-            + "/wms?SERVICE=WMS&amp;REQUEST=GetFeatureInfo\"/></Get>\n"
-            + "        </HTTP></DCPType>\n"
-            + "      </GetFeatureInfo>\n"
-            + "\n"
-            + "    </Request>\n"
-            + "\n"
-            + "    <Layer>\n"
-            + "      <Abstract>Direct access at "
-            + GEOSERVER
-            + "/wms (internal only)</Abstract>\n"
-            + "    </Layer>\n"
-            + "  </Capability>\n"
-            + "\n"
-            + "</WMS_Capabilities>";
+        String.format(
+            """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <WMS_Capabilities version="1.3.0"
+      	xmlns:xlink="http://www.w3.org/1999/xlink">
+      	<Service>
+      		<Name>WMS</Name>
+      		<Title>My GeoServer</Title>
+      		<OnlineResource xlink:href="%s?SERVICE=WMS"/>
+      	</Service>
+      	<Capability>
+      		<Request>
+      			<GetCapabilities>
+      				<DCPType>
+      					<HTTP>
+      						<Get>
+      							<OnlineResource  xlink:href="%s/wms?SERVICE=WMS&REQUEST=GetCapabilities"/>
+      						</Get>
+      						<Post>
+      							<OnlineResource xlink:href="%s/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities"/>
+      						</Post>
+      					</HTTP>
+      				</DCPType>
+      			</GetCapabilities>
+      			<GetMap>
+      				<DCPType>
+      					<HTTP>
+      						<Get>
+      							<OnlineResource xlink:href="%s/wms?SERVICE=WMS&amp;REQUEST=GetMap"/>
+      						</Get>
+      					</HTTP>
+      				</DCPType>
+      			</GetMap>
+      			<GetFeatureInfo>
+      				<DCPType>
+      					<HTTP>
+      						<Get>
+      							<OnlineResource xlink:href="%s/wms?SERVICE=WMS&amp;REQUEST=GetFeatureInfo"/>
+      						</Get>
+      					</HTTP>
+      				</DCPType>
+      			</GetFeatureInfo>
+      		</Request>
+      		<Layer>
+      			<Abstract>Direct access at %s/wms (internal only)</Abstract>
+      		</Layer>
+      	</Capability>
+      </WMS_Capabilities>
+      """,
+            GEOSERVER, GEOSERVER, GEOSERVER, GEOSERVER, GEOSERVER, GEOSERVER);
 
     final RequestExecutorResponseImpl<byte[]> resp = response(inputXml);
     decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));

--- a/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
+++ b/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +17,9 @@ import org.sitmun.proxy.middleware.service.RequestExecutorResponseImpl;
 @DisplayName("WmsCapabilitiesResponseDecorator")
 class WmsCapabilitiesResponseDecoratorTest {
 
-  public static final String PROXY_URL  = "https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4";
+  public static final String PROXY_URL = "https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4";
 
-  static final String GEOSERVER  = "https://some.domain.com/geoserver";
+  static final String GEOSERVER = "https://some.domain.com/geoserver";
 
   static final String SERVICE_URI = GEOSERVER + "/wms?SERVICE=WMS";
 
@@ -37,15 +36,15 @@ class WmsCapabilitiesResponseDecoratorTest {
 
   private WmsPayloadDto capabilitiesPayload(String uri) {
     return WmsPayloadDto.builder()
-      .uri(uri)
-      .method("GET")
-      .parameters(Map.of("REQUEST", "GetCapabilities", "SERVICE", "WMS"))
-      .build();
+        .uri(uri)
+        .method("GET")
+        .parameters(Map.of("REQUEST", "GetCapabilities", "SERVICE", "WMS"))
+        .build();
   }
 
   private RequestExecutorResponseImpl<byte[]> response(String xmlBody) {
     return new RequestExecutorResponseImpl<>(
-      PROXY_URL, 200, "application/xml", xmlBody.getBytes(StandardCharsets.UTF_8));
+        PROXY_URL, 200, "application/xml", xmlBody.getBytes(StandardCharsets.UTF_8));
   }
 
   private String bodyOf(RequestExecutorResponseImpl<byte[]> r) {
@@ -58,7 +57,8 @@ class WmsCapabilitiesResponseDecoratorTest {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("primaryReplacementCases")
-  void runReplacement(String name, String uri, String xmlBody, String shouldContain, String shouldNotContain) {
+  void runReplacement(
+      String name, String uri, String xmlBody, String shouldContain, String shouldNotContain) {
     final RequestExecutorResponseImpl<byte[]> resp = response(xmlBody);
     decorator.addBehavior(resp, capabilitiesPayload(uri));
     final String body = bodyOf(resp);
@@ -70,55 +70,58 @@ class WmsCapabilitiesResponseDecoratorTest {
 
   static Stream<Arguments> primaryReplacementCases() {
     return Stream.of(
-      Arguments.of(
-        "replaces /wfs suffix",
-        SERVICE_URI,
-        onlineResourceWrap(GEOSERVER + "/wfs?SERVICE=WFS"),
-        PROXY_URL + "?SERVICE=WFS",
-        null),
-      Arguments.of(
-        "replaces /wcs suffix",
-        SERVICE_URI,
-        onlineResourceWrap(GEOSERVER + "/wcs?SERVICE=WCS"),
-        PROXY_URL + "?SERVICE=WCS",
-        null),
-      Arguments.of(
-        "replaces /ows suffix",
-        SERVICE_URI,
-        onlineResourceWrap(GEOSERVER + "/ows?SERVICE=WMS"),
-        PROXY_URL + "?SERVICE=WMS",
-        null),
-      Arguments.of(
-        "replaces when single-quoted",
-        SERVICE_URI,
-        "<OnlineResource xlink:href='" + GEOSERVER + "/wms?SERVICE=WMS'/>",
-        PROXY_URL + "?SERVICE=WMS",
-        null),
-      Arguments.of(
-        "removes query string from URI before matching",
-        GEOSERVER + "/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0",
-        onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS"),
-        PROXY_URL + "?SERVICE=WMS",
-        null),
-      Arguments.of(
-        "does NOT replace a partial path match (/geoserver-v2)",
-        GEOSERVER + "/wms",
-        onlineResourceWrap("https://some.domain.com/geoserver-v2/wms?SERVICE=WMS"),
-        "https://some.domain.com/geoserver-v2/wms?SERVICE=WMS",
-        null),
-      Arguments.of(
-        "does NOT replace a URL from a different hostname if not defined in extra sources",
-        GEOSERVER + "/wms",
-        onlineResourceWrap("https://other.domain.com/geoserver/wms?SERVICE=WMS"),
-        "https://other.domain.com/geoserver/wms?SERVICE=WMS",
-        null)
-    );
+        Arguments.of(
+            "replaces /wfs suffix",
+            SERVICE_URI,
+            onlineResourceWrap(GEOSERVER + "/wfs?SERVICE=WFS"),
+            PROXY_URL + "?SERVICE=WFS",
+            null),
+        Arguments.of(
+            "replaces /wcs suffix",
+            SERVICE_URI,
+            onlineResourceWrap(GEOSERVER + "/wcs?SERVICE=WCS"),
+            PROXY_URL + "?SERVICE=WCS",
+            null),
+        Arguments.of(
+            "replaces /ows suffix",
+            SERVICE_URI,
+            onlineResourceWrap(GEOSERVER + "/ows?SERVICE=WMS"),
+            PROXY_URL + "?SERVICE=WMS",
+            null),
+        Arguments.of(
+            "replaces when single-quoted",
+            SERVICE_URI,
+            "<OnlineResource xlink:href='" + GEOSERVER + "/wms?SERVICE=WMS'/>",
+            PROXY_URL + "?SERVICE=WMS",
+            null),
+        Arguments.of(
+            "removes query string from URI before matching",
+            GEOSERVER + "/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0",
+            onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS"),
+            PROXY_URL + "?SERVICE=WMS",
+            null),
+        Arguments.of(
+            "does NOT replace a partial path match (/geoserver-v2)",
+            GEOSERVER + "/wms",
+            onlineResourceWrap("https://some.domain.com/geoserver-v2/wms?SERVICE=WMS"),
+            "https://some.domain.com/geoserver-v2/wms?SERVICE=WMS",
+            null),
+        Arguments.of(
+            "does NOT replace a URL from a different hostname if not defined in extra sources",
+            GEOSERVER + "/wms",
+            onlineResourceWrap("https://other.domain.com/geoserver/wms?SERVICE=WMS"),
+            "https://other.domain.com/geoserver/wms?SERVICE=WMS",
+            null));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("extraSourceCases")
-  void extraSourceReplacement(String name, List<String> extraSources, String payloadUri,
-      String xmlBody, String shouldContain) {
+  void extraSourceReplacement(
+      String name,
+      List<String> extraSources,
+      String payloadUri,
+      String xmlBody,
+      String shouldContain) {
     properties.setExtraSources(extraSources);
     final RequestExecutorResponseImpl<byte[]> resp = response(xmlBody);
     decorator.addBehavior(resp, capabilitiesPayload(payloadUri));
@@ -127,59 +130,68 @@ class WmsCapabilitiesResponseDecoratorTest {
 
   static Stream<Arguments> extraSourceCases() {
     return Stream.of(
-      Arguments.of(
-        "replaces extra source with /wms suffix",
-        List.of(BAD_CAPABILITIES_HOST),
-        SERVICE_URI,
-        onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS"),
-        PROXY_URL + "?SERVICE=WMS"),
-      Arguments.of(
-        "replaces extra source without OGC suffix",
-        List.of(BAD_CAPABILITIES_HOST),
-        SERVICE_URI,
-        onlineResourceWrap(BAD_CAPABILITIES_HOST + "?SERVICE=WMS"),
-        PROXY_URL + "?SERVICE=WMS"),
-      Arguments.of(
-        "normalizes extra source with trailing OGC suffix before matching",
-        List.of(BAD_CAPABILITIES_HOST + "/geoserver/wms"),
-        SERVICE_URI,
-        onlineResourceWrap(BAD_CAPABILITIES_HOST + "/geoserver/wfs?SERVICE=WFS"),
-        PROXY_URL + "?SERVICE=WFS"),
-      Arguments.of(
-        "does NOT replace unquoted extra source occurrence",
-        List.of(BAD_CAPABILITIES_HOST),
-        GEOSERVER + "/wms",
-        "<Description>See " + BAD_CAPABILITIES_HOST + "/wms for details</Description>",
-        BAD_CAPABILITIES_HOST + "/wms")
-    );
+        Arguments.of(
+            "replaces extra source with /wms suffix",
+            List.of(BAD_CAPABILITIES_HOST),
+            SERVICE_URI,
+            onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS"),
+            PROXY_URL + "?SERVICE=WMS"),
+        Arguments.of(
+            "replaces extra source without OGC suffix",
+            List.of(BAD_CAPABILITIES_HOST),
+            SERVICE_URI,
+            onlineResourceWrap(BAD_CAPABILITIES_HOST + "?SERVICE=WMS"),
+            PROXY_URL + "?SERVICE=WMS"),
+        Arguments.of(
+            "normalizes extra source with trailing OGC suffix before matching",
+            List.of(BAD_CAPABILITIES_HOST + "/geoserver/wms"),
+            SERVICE_URI,
+            onlineResourceWrap(BAD_CAPABILITIES_HOST + "/geoserver/wfs?SERVICE=WFS"),
+            PROXY_URL + "?SERVICE=WFS"),
+        Arguments.of(
+            "does NOT replace unquoted extra source occurrence",
+            List.of(BAD_CAPABILITIES_HOST),
+            GEOSERVER + "/wms",
+            "<Description>See " + BAD_CAPABILITIES_HOST + "/wms for details</Description>",
+            BAD_CAPABILITIES_HOST + "/wms"));
   }
 
   @Test
   @DisplayName("replaces all occurrences of multiple extra sources in the same document")
   void replacesMultipleExtraSources() {
-    properties.setExtraSources(List.of(BAD_CAPABILITIES_HOST, "http://192.168.1.10:8080/geoserver"));
-    final RequestExecutorResponseImpl<byte[]> resp = response(
-      "<a href=\"" + BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS\"/>"
-        + "<b href=\"http://192.168.1.10:8080/geoserver/wms?SERVICE=WMS\"/>");
+    properties.setExtraSources(
+        List.of(BAD_CAPABILITIES_HOST, "http://192.168.1.10:8080/geoserver"));
+    final RequestExecutorResponseImpl<byte[]> resp =
+        response(
+            "<a href=\""
+                + BAD_CAPABILITIES_HOST
+                + "/wms?SERVICE=WMS\"/>"
+                + "<b href=\"http://192.168.1.10:8080/geoserver/wms?SERVICE=WMS\"/>");
     decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
     assertThat(bodyOf(resp))
-      .doesNotContain(BAD_CAPABILITIES_HOST)
-      .doesNotContain("http://192.168.1.10:8080/geoserver")
-      .contains(PROXY_URL + "?SERVICE=WMS");
+        .doesNotContain(BAD_CAPABILITIES_HOST)
+        .doesNotContain("http://192.168.1.10:8080/geoserver")
+        .contains(PROXY_URL + "?SERVICE=WMS");
   }
 
   @Test
-  @DisplayName("replaces both the primary source and the extra source when both appear in the same document")
+  @DisplayName(
+      "replaces both the primary source and the extra source when both appear in the same document")
   void replacesBothPrimaryAndExtraSource() {
     properties.setExtraSources(List.of(BAD_CAPABILITIES_HOST));
-    final RequestExecutorResponseImpl<byte[]> resp = response(
-      "<Get>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Get>"
-        + "<Post>" + onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS") + "</Post>");
+    final RequestExecutorResponseImpl<byte[]> resp =
+        response(
+            "<Get>"
+                + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS")
+                + "</Get>"
+                + "<Post>"
+                + onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS")
+                + "</Post>");
     decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
     assertThat(bodyOf(resp))
-      .doesNotContain(GEOSERVER)
-      .doesNotContain(BAD_CAPABILITIES_HOST)
-      .contains(PROXY_URL + "?SERVICE=WMS");
+        .doesNotContain(GEOSERVER)
+        .doesNotContain(BAD_CAPABILITIES_HOST)
+        .contains(PROXY_URL + "?SERVICE=WMS");
   }
 
   @Test
@@ -187,52 +199,61 @@ class WmsCapabilitiesResponseDecoratorTest {
   void fullWmsCapabilitiesExample() {
     String inputXml =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        + "<WMS_Capabilities version=\"1.3.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
-        + "\n"
-        + "  <Service>\n"
-        + "    <Name>WMS</Name>\n"
-        + "    <Title>My GeoServer</Title>\n"
-        + "    <OnlineResource xlink:href=\"" + GEOSERVER + "?SERVICE=WMS\"/>\n"
-        + "  </Service>\n"
-        + "\n"
-        + "  <Capability>\n"
-        + "    <Request>\n"
-        + "\n"
-        + "      <GetCapabilities>\n"
-        + "        <DCPType><HTTP>\n"
-        + "          <Get><OnlineResource  xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Get>\n"
-        + "          <Post><OnlineResource xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Post>\n"
-        + "        </HTTP></DCPType>\n"
-        + "      </GetCapabilities>\n"
-        + "\n"
-        + "      <GetMap>\n"
-        + "        <DCPType><HTTP>\n"
-        + "          <Get><OnlineResource xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetMap\"/></Get>\n"
-        + "        </HTTP></DCPType>\n"
-        + "      </GetMap>\n"
-        + "\n"
-        + "      <GetFeatureInfo>\n"
-        + "        <DCPType><HTTP>\n"
-        + "          <Get><OnlineResource xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetFeatureInfo\"/></Get>\n"
-        + "        </HTTP></DCPType>\n"
-        + "      </GetFeatureInfo>\n"
-        + "\n"
-        + "    </Request>\n"
-        + "\n"
-        + "    <Layer>\n"
-        + "      <Abstract>Direct access at " + GEOSERVER + "/wms (internal only)</Abstract>\n"
-        + "    </Layer>\n"
-        + "  </Capability>\n"
-        + "\n"
-        + "</WMS_Capabilities>";
+            + "<WMS_Capabilities version=\"1.3.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
+            + "\n"
+            + "  <Service>\n"
+            + "    <Name>WMS</Name>\n"
+            + "    <Title>My GeoServer</Title>\n"
+            + "    <OnlineResource xlink:href=\""
+            + GEOSERVER
+            + "?SERVICE=WMS\"/>\n"
+            + "  </Service>\n"
+            + "\n"
+            + "  <Capability>\n"
+            + "    <Request>\n"
+            + "\n"
+            + "      <GetCapabilities>\n"
+            + "        <DCPType><HTTP>\n"
+            + "          <Get><OnlineResource  xlink:href=\""
+            + GEOSERVER
+            + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Get>\n"
+            + "          <Post><OnlineResource xlink:href=\""
+            + GEOSERVER
+            + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Post>\n"
+            + "        </HTTP></DCPType>\n"
+            + "      </GetCapabilities>\n"
+            + "\n"
+            + "      <GetMap>\n"
+            + "        <DCPType><HTTP>\n"
+            + "          <Get><OnlineResource xlink:href=\""
+            + GEOSERVER
+            + "/wms?SERVICE=WMS&amp;REQUEST=GetMap\"/></Get>\n"
+            + "        </HTTP></DCPType>\n"
+            + "      </GetMap>\n"
+            + "\n"
+            + "      <GetFeatureInfo>\n"
+            + "        <DCPType><HTTP>\n"
+            + "          <Get><OnlineResource xlink:href=\""
+            + GEOSERVER
+            + "/wms?SERVICE=WMS&amp;REQUEST=GetFeatureInfo\"/></Get>\n"
+            + "        </HTTP></DCPType>\n"
+            + "      </GetFeatureInfo>\n"
+            + "\n"
+            + "    </Request>\n"
+            + "\n"
+            + "    <Layer>\n"
+            + "      <Abstract>Direct access at "
+            + GEOSERVER
+            + "/wms (internal only)</Abstract>\n"
+            + "    </Layer>\n"
+            + "  </Capability>\n"
+            + "\n"
+            + "</WMS_Capabilities>";
 
     final RequestExecutorResponseImpl<byte[]> resp = response(inputXml);
     decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
     String result = bodyOf(resp);
 
-    // All quoted service URLs must be rewritten to the proxy URL,
-    // no quoted occurrence of the original service base should remain,
-    // and unquoted URLs in plain text (Abstract) must NOT be replaced.
     assertThat(result)
         .contains("xlink:href=\"" + PROXY_URL + "?SERVICE=WMS\"")
         .contains("xlink:href=\"" + PROXY_URL + "?SERVICE=WMS&amp;REQUEST=GetCapabilities\"")
@@ -245,8 +266,12 @@ class WmsCapabilitiesResponseDecoratorTest {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("servicePathCases")
-  void servicePathBehavior(String name, List<String> servicePaths, String payloadUri,
-      String xmlBody, String shouldContain) {
+  void servicePathBehavior(
+      String name,
+      List<String> servicePaths,
+      String payloadUri,
+      String xmlBody,
+      String shouldContain) {
     properties.setServicePaths(servicePaths);
     final RequestExecutorResponseImpl<byte[]> resp = response(xmlBody);
     decorator.addBehavior(resp, capabilitiesPayload(payloadUri));
@@ -255,18 +280,17 @@ class WmsCapabilitiesResponseDecoratorTest {
 
   static Stream<Arguments> servicePathCases() {
     return Stream.of(
-      Arguments.of(
-        "custom suffix added to service-paths is recognized as an OGC endpoint",
-        List.of("wms", "arcgis"),
-        "https://some.domain.com/service/arcgis?SERVICE=WMS",
-        onlineResourceWrap("https://some.domain.com/service/arcgis?SERVICE=WMS"),
-        PROXY_URL + "?SERVICE=WMS"),
-      Arguments.of(
-        "suffix removed from service-paths is no longer matched as an OGC endpoint",
-        List.of("wms"),
-        GEOSERVER + "/wms",
-        onlineResourceWrap(GEOSERVER + "/ows?SERVICE=WMS"),
-        GEOSERVER + "/ows?SERVICE=WMS")
-    );
+        Arguments.of(
+            "custom suffix added to service-paths is recognized as an OGC endpoint",
+            List.of("wms", "arcgis"),
+            "https://some.domain.com/service/arcgis?SERVICE=WMS",
+            onlineResourceWrap("https://some.domain.com/service/arcgis?SERVICE=WMS"),
+            PROXY_URL + "?SERVICE=WMS"),
+        Arguments.of(
+            "suffix removed from service-paths is no longer matched as an OGC endpoint",
+            List.of("wms"),
+            GEOSERVER + "/wms",
+            onlineResourceWrap(GEOSERVER + "/ows?SERVICE=WMS"),
+            GEOSERVER + "/ows?SERVICE=WMS"));
   }
 }

--- a/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
+++ b/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
@@ -1,0 +1,236 @@
+package org.sitmun.proxy.middleware.protocols.wms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sitmun.proxy.middleware.service.RequestExecutorResponseImpl;
+
+@DisplayName("WmsCapabilitiesResponseDecorator")
+class WmsCapabilitiesResponseDecoratorTest {
+
+  public static final String PROXY_URL  = "https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4";
+
+  static final String GEOSERVER  = "https://some.domain.com/geoserver";
+
+  static final String SERVICE_URI = GEOSERVER + "/wms?SERVICE=WMS";
+
+  static final String BAD_CAPABILITIES_HOST = "http://localhost:3000";
+
+  private WmsCapabilitiesProperties properties;
+  private WmsCapabilitiesResponseDecorator decorator;
+
+  @BeforeEach
+  void setUp() {
+    properties = new WmsCapabilitiesProperties();
+    decorator = new WmsCapabilitiesResponseDecorator(properties);
+  }
+
+  private WmsPayloadDto capabilitiesPayload(String uri) {
+    return WmsPayloadDto.builder()
+      .uri(uri)
+      .method("GET")
+      .parameters(Map.of("REQUEST", "GetCapabilities", "SERVICE", "WMS"))
+      .build();
+  }
+
+  private RequestExecutorResponseImpl<byte[]> response(String xmlBody) {
+    return new RequestExecutorResponseImpl<>(
+      PROXY_URL, 200, "application/xml", xmlBody.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private String bodyOf(RequestExecutorResponseImpl<byte[]> r) {
+    return new String(r.getBody(), StandardCharsets.UTF_8);
+  }
+
+  private static String onlineResourceWrap(String url) {
+    return "<OnlineResource xlink:href=\"" + url + "\"/>";
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("primaryReplacementCases")
+  void runReplacement(String name, String uri, String xmlBody, String shouldContain, String shouldNotContain) {
+    final RequestExecutorResponseImpl<byte[]> resp = response(xmlBody);
+    decorator.addBehavior(resp, capabilitiesPayload(uri));
+    final String body = bodyOf(resp);
+    assertThat(body).contains(shouldContain);
+    if (shouldNotContain != null) {
+      assertThat(body).doesNotContain(shouldNotContain);
+    }
+  }
+
+  static Stream<Arguments> primaryReplacementCases() {
+    return Stream.of(
+      Arguments.of(
+        "replaces /wms suffix",
+        GEOSERVER + "/wms?SERVICE=WMS&REQUEST=GetCapabilities",
+        onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS"),
+        PROXY_URL + "?SERVICE=WMS",
+        GEOSERVER),
+      Arguments.of(
+        "replaces /wfs suffix",
+        SERVICE_URI,
+        onlineResourceWrap(GEOSERVER + "/wfs?SERVICE=WFS"),
+        PROXY_URL + "?SERVICE=WFS",
+        null),
+      Arguments.of(
+        "replaces /wcs suffix",
+        SERVICE_URI,
+        onlineResourceWrap(GEOSERVER + "/wcs?SERVICE=WCS"),
+        PROXY_URL + "?SERVICE=WCS",
+        null),
+      Arguments.of(
+        "replaces /ows suffix",
+        SERVICE_URI,
+        onlineResourceWrap(GEOSERVER + "/ows?SERVICE=WMS"),
+        PROXY_URL + "?SERVICE=WMS",
+        null),
+      Arguments.of(
+        "replaces URL without OGC suffix",
+        SERVICE_URI,
+        onlineResourceWrap(GEOSERVER + "?REQUEST=GetCapabilities"),
+        PROXY_URL + "?REQUEST=GetCapabilities",
+        null),
+      Arguments.of(
+        "replaces when single-quoted",
+        SERVICE_URI,
+        "<OnlineResource xlink:href='" + GEOSERVER + "/wms?SERVICE=WMS'/>",
+        PROXY_URL + "?SERVICE=WMS",
+        null),
+      Arguments.of(
+        "replaces all occurrences",
+        SERVICE_URI,
+        "<Get>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Get>"
+          + "<Post>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Post>",
+        PROXY_URL + "?SERVICE=WMS",
+        GEOSERVER),
+      Arguments.of(
+        "removes query string from URI before matching",
+        GEOSERVER + "/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0",
+        onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS"),
+        PROXY_URL + "?SERVICE=WMS",
+        null),
+      Arguments.of(
+        "does NOT replace non-quoted matches",
+        GEOSERVER + "/wms",
+        "<Description>See " + GEOSERVER + "/wms for details</Description>",
+        GEOSERVER + "/wms",
+        null),
+      Arguments.of(
+        "does NOT replace a partial path match (/geoserver-v2)",
+        GEOSERVER + "/wms",
+        onlineResourceWrap("https://some.domain.com/geoserver-v2/wms?SERVICE=WMS"),
+        "https://some.domain.com/geoserver-v2/wms?SERVICE=WMS",
+        null),
+      Arguments.of(
+        "does NOT replace a URL from a different hostname if not defined in extra sources",
+        GEOSERVER + "/wms",
+        onlineResourceWrap("https://other.domain.com/geoserver/wms?SERVICE=WMS"),
+        "https://other.domain.com/geoserver/wms?SERVICE=WMS",
+        null)
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("extraSourceCases")
+  void extraSourceReplacement(String name, List<String> extraSources, String payloadUri,
+      String xmlBody, String shouldContain) {
+    properties.setExtraSources(extraSources);
+    final RequestExecutorResponseImpl<byte[]> resp = response(xmlBody);
+    decorator.addBehavior(resp, capabilitiesPayload(payloadUri));
+    assertThat(bodyOf(resp)).contains(shouldContain);
+  }
+
+  static Stream<Arguments> extraSourceCases() {
+    return Stream.of(
+      Arguments.of(
+        "replaces extra source with /wms suffix",
+        List.of(BAD_CAPABILITIES_HOST),
+        SERVICE_URI,
+        onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS"),
+        PROXY_URL + "?SERVICE=WMS"),
+      Arguments.of(
+        "replaces extra source without OGC suffix",
+        List.of(BAD_CAPABILITIES_HOST),
+        SERVICE_URI,
+        onlineResourceWrap(BAD_CAPABILITIES_HOST + "?SERVICE=WMS"),
+        PROXY_URL + "?SERVICE=WMS"),
+      Arguments.of(
+        "normalizes extra source with trailing OGC suffix before matching",
+        List.of(BAD_CAPABILITIES_HOST + "/geoserver/wms"),
+        SERVICE_URI,
+        onlineResourceWrap(BAD_CAPABILITIES_HOST + "/geoserver/wfs?SERVICE=WFS"),
+        PROXY_URL + "?SERVICE=WFS"),
+      Arguments.of(
+        "does NOT replace unquoted extra source occurrence",
+        List.of(BAD_CAPABILITIES_HOST),
+        GEOSERVER + "/wms",
+        "<Description>See " + BAD_CAPABILITIES_HOST + "/wms for details</Description>",
+        BAD_CAPABILITIES_HOST + "/wms")
+    );
+  }
+
+  @Test
+  @DisplayName("replaces all occurrences of multiple extra sources in the same document")
+  void replacesMultipleExtraSources() {
+    properties.setExtraSources(List.of(BAD_CAPABILITIES_HOST, "http://192.168.1.10:8080/geoserver"));
+    var resp = response(
+      "<a href=\"" + BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS\"/>"
+        + "<b href=\"http://192.168.1.10:8080/geoserver/wms?SERVICE=WMS\"/>");
+    decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
+    assertThat(bodyOf(resp))
+      .doesNotContain(BAD_CAPABILITIES_HOST)
+      .doesNotContain("http://192.168.1.10:8080/geoserver")
+      .contains(PROXY_URL + "?SERVICE=WMS");
+  }
+
+  @Test
+  @DisplayName("replaces both the primary source and the extra source when both appear in the same document")
+  void replacesBothPrimaryAndExtraSource() {
+    properties.setExtraSources(List.of(BAD_CAPABILITIES_HOST));
+    var resp = response(
+      "<Get>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Get>"
+        + "<Post>" + onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS") + "</Post>");
+    decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
+    assertThat(bodyOf(resp))
+      .doesNotContain(GEOSERVER)
+      .doesNotContain(BAD_CAPABILITIES_HOST)
+      .contains(PROXY_URL + "?SERVICE=WMS");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("servicePathCases")
+  void servicePathBehavior(String name, List<String> servicePaths, String payloadUri,
+      String xmlBody, String shouldContain) {
+    properties.setServicePaths(servicePaths);
+    var resp = response(xmlBody);
+    decorator.addBehavior(resp, capabilitiesPayload(payloadUri));
+    assertThat(bodyOf(resp)).contains(shouldContain);
+  }
+
+  static Stream<Arguments> servicePathCases() {
+    return Stream.of(
+      Arguments.of(
+        "custom suffix added to service-paths is recognized as an OGC endpoint",
+        List.of("wms", "arcgis"),
+        "https://some.domain.com/service/arcgis?SERVICE=WMS",
+        onlineResourceWrap("https://some.domain.com/service/arcgis?SERVICE=WMS"),
+        PROXY_URL + "?SERVICE=WMS"),
+      Arguments.of(
+        "suffix removed from service-paths is no longer matched as an OGC endpoint",
+        List.of("wms"),
+        GEOSERVER + "/wms",
+        onlineResourceWrap(GEOSERVER + "/ows?SERVICE=WMS"),
+        GEOSERVER + "/ows?SERVICE=WMS")
+    );
+  }
+}

--- a/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
+++ b/src/test/java/org/sitmun/proxy/middleware/protocols/wms/WmsCapabilitiesResponseDecoratorTest.java
@@ -71,12 +71,6 @@ class WmsCapabilitiesResponseDecoratorTest {
   static Stream<Arguments> primaryReplacementCases() {
     return Stream.of(
       Arguments.of(
-        "replaces /wms suffix",
-        GEOSERVER + "/wms?SERVICE=WMS&REQUEST=GetCapabilities",
-        onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS"),
-        PROXY_URL + "?SERVICE=WMS",
-        GEOSERVER),
-      Arguments.of(
         "replaces /wfs suffix",
         SERVICE_URI,
         onlineResourceWrap(GEOSERVER + "/wfs?SERVICE=WFS"),
@@ -95,35 +89,16 @@ class WmsCapabilitiesResponseDecoratorTest {
         PROXY_URL + "?SERVICE=WMS",
         null),
       Arguments.of(
-        "replaces URL without OGC suffix",
-        SERVICE_URI,
-        onlineResourceWrap(GEOSERVER + "?REQUEST=GetCapabilities"),
-        PROXY_URL + "?REQUEST=GetCapabilities",
-        null),
-      Arguments.of(
         "replaces when single-quoted",
         SERVICE_URI,
         "<OnlineResource xlink:href='" + GEOSERVER + "/wms?SERVICE=WMS'/>",
         PROXY_URL + "?SERVICE=WMS",
         null),
       Arguments.of(
-        "replaces all occurrences",
-        SERVICE_URI,
-        "<Get>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Get>"
-          + "<Post>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Post>",
-        PROXY_URL + "?SERVICE=WMS",
-        GEOSERVER),
-      Arguments.of(
         "removes query string from URI before matching",
         GEOSERVER + "/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0",
         onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS"),
         PROXY_URL + "?SERVICE=WMS",
-        null),
-      Arguments.of(
-        "does NOT replace non-quoted matches",
-        GEOSERVER + "/wms",
-        "<Description>See " + GEOSERVER + "/wms for details</Description>",
-        GEOSERVER + "/wms",
         null),
       Arguments.of(
         "does NOT replace a partial path match (/geoserver-v2)",
@@ -183,7 +158,7 @@ class WmsCapabilitiesResponseDecoratorTest {
   @DisplayName("replaces all occurrences of multiple extra sources in the same document")
   void replacesMultipleExtraSources() {
     properties.setExtraSources(List.of(BAD_CAPABILITIES_HOST, "http://192.168.1.10:8080/geoserver"));
-    var resp = response(
+    final RequestExecutorResponseImpl<byte[]> resp = response(
       "<a href=\"" + BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS\"/>"
         + "<b href=\"http://192.168.1.10:8080/geoserver/wms?SERVICE=WMS\"/>");
     decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
@@ -197,7 +172,7 @@ class WmsCapabilitiesResponseDecoratorTest {
   @DisplayName("replaces both the primary source and the extra source when both appear in the same document")
   void replacesBothPrimaryAndExtraSource() {
     properties.setExtraSources(List.of(BAD_CAPABILITIES_HOST));
-    var resp = response(
+    final RequestExecutorResponseImpl<byte[]> resp = response(
       "<Get>" + onlineResourceWrap(GEOSERVER + "/wms?SERVICE=WMS") + "</Get>"
         + "<Post>" + onlineResourceWrap(BAD_CAPABILITIES_HOST + "/wms?SERVICE=WMS") + "</Post>");
     decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
@@ -207,12 +182,73 @@ class WmsCapabilitiesResponseDecoratorTest {
       .contains(PROXY_URL + "?SERVICE=WMS");
   }
 
+  @Test
+  @DisplayName("replaces all quoted URLs in a full WMS GetCapabilities response")
+  void fullWmsCapabilitiesExample() {
+    String inputXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<WMS_Capabilities version=\"1.3.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
+        + "\n"
+        + "  <Service>\n"
+        + "    <Name>WMS</Name>\n"
+        + "    <Title>My GeoServer</Title>\n"
+        + "    <OnlineResource xlink:href=\"" + GEOSERVER + "?SERVICE=WMS\"/>\n"
+        + "  </Service>\n"
+        + "\n"
+        + "  <Capability>\n"
+        + "    <Request>\n"
+        + "\n"
+        + "      <GetCapabilities>\n"
+        + "        <DCPType><HTTP>\n"
+        + "          <Get><OnlineResource  xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Get>\n"
+        + "          <Post><OnlineResource xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities\"/></Post>\n"
+        + "        </HTTP></DCPType>\n"
+        + "      </GetCapabilities>\n"
+        + "\n"
+        + "      <GetMap>\n"
+        + "        <DCPType><HTTP>\n"
+        + "          <Get><OnlineResource xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetMap\"/></Get>\n"
+        + "        </HTTP></DCPType>\n"
+        + "      </GetMap>\n"
+        + "\n"
+        + "      <GetFeatureInfo>\n"
+        + "        <DCPType><HTTP>\n"
+        + "          <Get><OnlineResource xlink:href=\"" + GEOSERVER + "/wms?SERVICE=WMS&amp;REQUEST=GetFeatureInfo\"/></Get>\n"
+        + "        </HTTP></DCPType>\n"
+        + "      </GetFeatureInfo>\n"
+        + "\n"
+        + "    </Request>\n"
+        + "\n"
+        + "    <Layer>\n"
+        + "      <Abstract>Direct access at " + GEOSERVER + "/wms (internal only)</Abstract>\n"
+        + "    </Layer>\n"
+        + "  </Capability>\n"
+        + "\n"
+        + "</WMS_Capabilities>";
+
+    final RequestExecutorResponseImpl<byte[]> resp = response(inputXml);
+    decorator.addBehavior(resp, capabilitiesPayload(SERVICE_URI));
+    String result = bodyOf(resp);
+
+    // All quoted service URLs must be rewritten to the proxy URL,
+    // no quoted occurrence of the original service base should remain,
+    // and unquoted URLs in plain text (Abstract) must NOT be replaced.
+    assertThat(result)
+        .contains("xlink:href=\"" + PROXY_URL + "?SERVICE=WMS\"")
+        .contains("xlink:href=\"" + PROXY_URL + "?SERVICE=WMS&amp;REQUEST=GetCapabilities\"")
+        .contains("xlink:href=\"" + PROXY_URL + "?SERVICE=WMS&amp;REQUEST=GetMap\"")
+        .contains("xlink:href=\"" + PROXY_URL + "?SERVICE=WMS&amp;REQUEST=GetFeatureInfo\"")
+        .doesNotContain("\"" + GEOSERVER)
+        .doesNotContain("'" + GEOSERVER)
+        .contains("Direct access at " + GEOSERVER + "/wms (internal only)");
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("servicePathCases")
   void servicePathBehavior(String name, List<String> servicePaths, String payloadUri,
       String xmlBody, String shouldContain) {
     properties.setServicePaths(servicePaths);
-    var resp = response(xmlBody);
+    final RequestExecutorResponseImpl<byte[]> resp = response(xmlBody);
     decorator.addBehavior(resp, capabilitiesPayload(payloadUri));
     assertThat(bodyOf(resp)).contains(shouldContain);
   }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,3 +16,11 @@ sitmun:
     config:
       url: http://localhost:8080/api/config/proxy
       secret: 9ef80c644166846897f6a87d3cf6ab204d144229
+  ogc:
+    capabilities:
+      service-paths:
+        - wms
+        - wfs
+        - wcs
+        - ows
+      extra-sources: []


### PR DESCRIPTION
Solves issues on proxied services that return unexpected URLs in GetCapabilities response by providing replacement customization via application.yml or environment variables.
 
Using the existing decorator, base behaviour stays the same, replacing service URL as is first. Then, based on configured OGC service paths and extra sources that may be encountered in capabilities response, those are replaced as well.
 
For example:
 
Given configuration:
 
```bash
  wms:
    capabilities:
      # OGC service path suffixes recognized when rewriting URLs in GetCapabilities responses.
      service-paths:
        - wms
        - wfs
        - wcs
        - ows
      # Optional extra source URL prefixes to replace with the proxy URL (empty list by default).
      extra-sources:
       - http://localhost:3000/
       - http://internal-geoserver:8080/geoserver
```
 
Every quoted (to avoid false positives) URL that matches either of the 2 extra sources until OGC service path (not included) or matches the exact stored service URL +optionally any of the OGC service paths is replaced. So, in this case, if received capabilities from (proxied) https://geoserver.example.com/geoserver looks like this:
 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<WMS_Capabilities version="1.3.0"
	xmlns:xlink="http://www.w3.org/1999/xlink">
	<Service>
		<Name>WMS</Name>
		<Title>My GeoServer</Title>
		<OnlineResource xlink:href="https://geoserver.example.com/geoserver?SERVICE=WMS"/>
	</Service>
	<Capability>
		<Request>
			<GetCapabilities>
				<DCPType>
					<HTTP>
						<Get>
							<OnlineResource  xlink:href="https://geoserver.example.com/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities"/>
						</Get>
						<Post>
							<OnlineResource xlink:href="https://geoserver.example.com/geoserver/wms?SERVICE=WMS&amp;REQUEST=GetCapabilities"/>
						</Post>
					</HTTP>
				</DCPType>
			</GetCapabilities>
			<GetMap>
				<DCPType>
					<HTTP>
						<Get>
							<OnlineResource xlink:href="https://geoserver.example.com/geoserver/wms?SERVICE=WMS&amp;REQUEST=GetMap"/>
						</Get>
					</HTTP>
				</DCPType>
			</GetMap>
			<GetFeatureInfo>
				<DCPType>
					<HTTP>
						<Get>
							<OnlineResource xlink:href="https://geoserver.example.com/geoserver/wms?SERVICE=WMS&amp;REQUEST=GetFeatureInfo"/>
						</Get>
					</HTTP>
				</DCPType>
			</GetFeatureInfo>
		</Request>
		<Layer>
			<Abstract>Direct access at https://geoserver.example.com/geoserver/wms (internal only)</Abstract>
		</Layer>
	</Capability>
</WMS_Capabilities>
```
 
The final capabilities would look like this:
 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<WMS_Capabilities version="1.3.0"
	xmlns:xlink="http://www.w3.org/1999/xlink">
	<Service>
		<Name>WMS</Name>
		<Title>My GeoServer</Title>
		<OnlineResource xlink:href="https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4?SERVICE=WMS"/>
	</Service>
	<Capability>
		<Request>
			<GetCapabilities>
				<DCPType>
					<HTTP>
						<Get>
							<OnlineResource  xlink:href="https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4?SERVICE=WMS&amp;REQUEST=GetCapabilities"/>
						</Get>
						<Post>
							<OnlineResource xlink:href="https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4?SERVICE=WMS&amp;REQUEST=GetCapabilities"/>
						</Post>
					</HTTP>
				</DCPType>
			</GetCapabilities>
			<GetMap>
				<DCPType>
					<HTTP>
						<Get>
							<OnlineResource xlink:href="https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4?SERVICE=WMS&amp;REQUEST=GetMap"/>
						</Get>
					</HTTP>
				</DCPType>
			</GetMap>
			<GetFeatureInfo>
				<DCPType>
					<HTTP>
						<Get>
							<OnlineResource xlink:href="https://proxy.sitmun.org/middleware/proxy/3/66/WMS/4?SERVICE=WMS&amp;REQUEST=GetFeatureInfo"/>
						</Get>
					</HTTP>
				</DCPType>
			</GetFeatureInfo>
		</Request>
		<Layer>
			<Abstract>Direct access at https://geoserver.example.com/geoserver/wms (internal only)</Abstract>
		</Layer>
	</Capability>
</WMS_Capabilities>
```